### PR TITLE
A minor change that prevents an overflow

### DIFF
--- a/template/beamerouterthemesmalltree.sty
+++ b/template/beamerouterthemesmalltree.sty
@@ -88,10 +88,10 @@
 \defbeamertemplate*{slide progress}{default}
 {%
   \raisebox{-1.8pt}{\begin{tikzpicture}
-    \pgfmathparse{(360*\insertframenumber)/\inserttotalframenumber};
+    \pgfmathparse{(\insertframestartpage/\inserttotalframenumber)*360};
     \def\res{\pgfmathresult}
-    \fill[bleu] (0,0) -- (0,5pt) arc(90:90+(360*\insertframenumber)/\inserttotalframenumber:5pt) -- cycle;
-    \node[draw, circle, bleu, font=\scriptsize\bf, inner sep=1pt, minimum size=10.5pt] at (0, 0) {\textcolor{white}{\insertframenumber{}}};
+   \fill[bleu] (0,0) -- (0,5pt) arc(90:90+(\insertframenumber/\inserttotalframenumber)*360:5pt) -- cycle; 
+    \node[draw, circle, bleu, font=\scriptsize\bf, inner sep=1pt, minimum size=10.5pt] at (0, 0) {\textcolor{white}{\insertframenumber}};
   \end{tikzpicture}}
 }
 


### PR DESCRIPTION
`360*\insertframenumber` can cause an overflow if there are too many slides (>45) 